### PR TITLE
Update open_cygwin_windows_prompt.bat

### DIFF
--- a/native_build/windows/open_cygwin_windows_prompt.bat
+++ b/native_build/windows/open_cygwin_windows_prompt.bat
@@ -1,4 +1,5 @@
 @setlocal
+@cd /d "%~d0%~p0"
 @ECHO cd to 
 @.\ffmpeg_local_builds\cygwin_local_install\bin\cygpath.exe -a ffmpeg_local_builds
 @echo "for the root ffmpeg build dir"


### PR DESCRIPTION
Adding this line you can use the standard "Run as administrator" right-click menu in Windows higher than XP. Otherwise, the .bat opens in `%SystemRoot%\system32` path and the two `cygwin` commands fail. It doesn't hurt either when run double-clicking.